### PR TITLE
Enable Deeptest Micro Butcher

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,3 +1,5 @@
 buildCmd: cd symphony-client; mvn compile
 testCmd: cd symphony-client; mvn test
 ignoreExistingCoverage: true
+cbmcArguments:
+  slice-function-calls: org.slf4j.Logger


### PR DESCRIPTION
This will remove the analysis of the logging mechanism which typically does not have any effect on the test cases. This I expect will increase the coverage by >3%