### PR TITLE
Update argument format for micro-slicer

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -2,4 +2,4 @@ buildCmd: cd symphony-client; mvn compile
 testCmd: cd symphony-client; mvn test
 ignoreExistingCoverage: true
 cbmcArguments:
-  slice-function-calls: org.slf4j.Logger
+  slice-function-calls: "org\.slf4j\.Logger.*"


### PR DESCRIPTION
The working changed from regex `find` to `match`, therefore we have to match the
complete function call, not just any prefix.